### PR TITLE
refactor: harden SoT/mux core for extensibility and stability

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,14 +29,17 @@ jobs:
         python -m pip install --upgrade pip
         pip install -e .[dev]
 
-    #- name: Run tests
-    #  run: |
-    #    pytest tests/ -v --cov=sshplex --cov-report=xml
+    - name: Lint with ruff
+      run: |
+        ruff check sshplex tests
 
-    #- name: Upload coverage to Codecov
-    #  uses: codecov/codecov-action@v3
-    #  with:
-    #    file: ./coverage.xml
+    - name: Type check with mypy
+      run: |
+        mypy sshplex --ignore-missing-imports
+
+    - name: Test with pytest
+      run: |
+        pytest tests/ -v
 
   build:
     needs: test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+- Simplified SoT activation flow: when `sot.providers` is empty, enabled provider types are inferred from configured imports.
+- Standardized provider and mux backend catalogs via shared config constants to reduce cross-file edits for future extensions.
+- Removed git-import compatibility plumbing around legacy `path`/`file_glob`; git imports now rely on canonical `source_pattern`.
+- Updated packaging metadata to match runtime reality: Python `>=3.10`.
+
+### Fixed
+- Made host cache writes atomic to prevent partial cache corruption on interrupted writes.
+- Fixed cache path handling to always expand `~` and normalized cache-key behavior for filtered host loads.
+- Fixed SoTFactory in-memory cache collisions so different filters do not reuse the wrong host sets.
+- Moved NetBox dependency loading to runtime (`pynetbox` lazy import) for cleaner optional-dependency failure handling.
+- Hardened SSH command building for key/known_hosts paths with spaces and normalized proxy key path expansion.
+- Prevented host-loading modal pop mismatches by using modal dismissal instead of generic `pop_screen()`.
+- Moved tmux session list refresh operations off the UI thread to keep the TUI responsive during session scans.
+
 ## [1.7.0] - 2026-03-01
 
 ### Added

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -179,7 +179,7 @@ Use [Semantic Versioning](https://semver.org/):
 ### Continuous Integration (`ci.yml`)
 
 Runs on every push and pull request:
-- Tests across Python 3.8-3.12
+- Tests across Python 3.10-3.13
 - Linting with flake8
 - Type checking with mypy
 - Code coverage reporting

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ sshplex
 
 ### Prerequisites
 
-- Python 3.8+
+- Python 3.10+
 - tmux (Linux/macOS) and/or iTerm2 (macOS)
 - SSH key configured for target hosts
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -83,7 +83,8 @@ tmux:
 | Consul | `consul` | Add `consul` to `sot.providers` | `config.host`, `config.token` |
 | Git | `git` | Add `git` to `sot.providers` | `repo_url` |
 
-Only imports whose `type` is listed in `sot.providers` are loaded.
+When `sot.providers` is set, only imports whose `type` is listed are loaded.
+If `sot.providers` is omitted or empty, SSHplex infers enabled types from the configured imports.
 
 ```yaml
 sot:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -60,7 +60,7 @@ logging:
 |-------|----------|
 | NetBox connection failed | Check URL, token, and network connectivity |
 | Ansible inventory not loading | Verify file paths exist and YAML syntax is valid |
-| Import configured but hosts never appear | Ensure import `type` is enabled in `sot.providers` |
+| Import configured but hosts never appear | Ensure import `type` is enabled in `sot.providers` (or leave providers empty to auto-infer from imports) |
 | No hosts found | Remove filters temporarily, check provider logs |
 | Consul import error | Install with `pip install "sshplex[consul]"` |
 | Git import clone/pull fails | Verify `git` is installed, repo URL/auth, and branch exists |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,17 +18,16 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: System :: Networking",
     "Topic :: System :: Systems Administration",
     "Topic :: Terminals",
 ]
 keywords = ["ssh", "tmux", "multiplexer", "netbox", "tui", "terminal"]
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
     "pynetbox==7.6.1",
     "textual==8.0.0",

--- a/sshplex/cli.py
+++ b/sshplex/cli.py
@@ -143,7 +143,7 @@ def list_providers(config: Any, logger: Any) -> int:
             branch = provider.branch or "main"
             inventory_format = provider.inventory_format or "static"
             print(f"   Repo: {provider.repo_url} [{branch}, {inventory_format}]")
-            source_pattern = provider.source_pattern or f"{provider.path}/{provider.file_glob}"
+            source_pattern = provider.source_pattern or "hosts/**/*.y*ml"
             print(f"   Source: {source_pattern}")
         elif provider.type == "static" and provider.hosts:
             print(f"   Hosts: {len(provider.hosts)} defined")

--- a/sshplex/lib/cache.py
+++ b/sshplex/lib/cache.py
@@ -1,6 +1,8 @@
 """SSHplex host cache management for optimized startup performance."""
 
+import contextlib
 import os
+import tempfile
 import threading
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -28,9 +30,9 @@ class HostCache:
         self.logger = get_logger()
 
         if cache_dir is None:
-            cache_dir = os.path.expanduser("~/.cache/sshplex")
+            cache_dir = "~/.cache/sshplex"
 
-        self.cache_dir = Path(cache_dir)
+        self.cache_dir = Path(cache_dir).expanduser()
         self.cache_ttl = timedelta(hours=cache_ttl_hours)
         self.cache_file = self.cache_dir / "hosts.yaml"
         self.metadata_file = self.cache_dir / "cache_metadata.yaml"
@@ -70,18 +72,36 @@ class HostCache:
                 with open(self.metadata_file) as f:
                     metadata = yaml.safe_load(f)
 
-                if not metadata or 'timestamp' not in metadata:
+                if not isinstance(metadata, dict) or 'timestamp' not in metadata:
                     return False
 
                 cache_time = datetime.fromisoformat(metadata['timestamp'])
                 return datetime.now() - cache_time < self.cache_ttl
 
-            except (yaml.YAMLError, ValueError, KeyError) as e:
+            except (yaml.YAMLError, ValueError, KeyError, OSError) as e:
                 self.logger.warning(f"Failed to validate cache: {e}")
                 return False
             except Exception as e:
                 self.logger.error(f"Unexpected error validating cache: {e}")
                 return False
+
+    def _atomic_write_yaml(self, file_path: Path, payload: Any) -> None:
+        """Write YAML payload atomically to avoid partial/corrupt cache writes."""
+        fd, temp_path_text = tempfile.mkstemp(
+            prefix=f".{file_path.name}.",
+            suffix=".tmp",
+            dir=str(self.cache_dir),
+            text=True,
+        )
+        temp_path = Path(temp_path_text)
+        try:
+            with os.fdopen(fd, "w") as handle:
+                yaml.safe_dump(payload, handle, default_flow_style=False, sort_keys=True)
+            os.replace(temp_path, file_path)
+        finally:
+            if temp_path.exists():
+                with contextlib.suppress(OSError):
+                    temp_path.unlink()
 
     def save_hosts(self, hosts: List[Host], provider_info: Dict[str, Any]) -> bool:
         """Save hosts to cache with metadata.
@@ -95,19 +115,10 @@ class HostCache:
         """
         with self._lock:
             try:
-                # Prepare hosts data for serialization
-                hosts_data = []
-                for host in hosts:
-                    host_dict = {
-                        'name': host.name,
-                        'ip': host.ip,
-                        'metadata': host.metadata
-                    }
-                    hosts_data.append(host_dict)
+                hosts_data = [host.to_dict() for host in hosts]
 
                 # Save hosts data
-                with open(self.cache_file, 'w') as f:
-                    yaml.dump(hosts_data, f, default_flow_style=False, sort_keys=True)
+                self._atomic_write_yaml(self.cache_file, hosts_data)
 
                 # Save metadata
                 cache_metadata = {
@@ -117,8 +128,7 @@ class HostCache:
                     'cache_version': '1.0'
                 }
 
-                with open(self.metadata_file, 'w') as f:
-                    yaml.dump(cache_metadata, f, default_flow_style=False, sort_keys=True)
+                self._atomic_write_yaml(self.metadata_file, cache_metadata)
 
                 self.logger.info(f"Successfully cached {len(hosts)} hosts to {self.cache_file}")
                 return True
@@ -155,12 +165,8 @@ class HostCache:
                     if 'name' not in host_dict or 'ip' not in host_dict:
                         self.logger.warning(f"Skipping host with missing required fields: {host_dict}")
                         continue
-                        
-                    host = Host(
-                        name=host_dict['name'],
-                        ip=host_dict['ip'],
-                        **host_dict.get('metadata', {})
-                    )
+
+                    host = Host.from_dict(host_dict)
                     hosts.append(host)
 
                 self.logger.info(f"Successfully loaded {len(hosts)} hosts from cache")

--- a/sshplex/lib/config.py
+++ b/sshplex/lib/config.py
@@ -5,24 +5,32 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import yaml
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from .. import __version__
+
+SUPPORTED_SOT_PROVIDER_TYPES = ("static", "netbox", "ansible", "consul", "git")
+SOT_PROVIDER_LABELS = {
+    "static": "Static",
+    "netbox": "NetBox",
+    "ansible": "Ansible",
+    "consul": "Consul",
+    "git": "Git",
+}
+
+SUPPORTED_MUX_BACKENDS = ("tmux", "iterm2-native")
+MUX_BACKEND_LABELS = {
+    "tmux": "tmux",
+    "iterm2-native": "iTerm2 Native",
+}
+
+SUPPORTED_GIT_INVENTORY_FORMATS = ("static", "ansible")
 
 
 class SSHplexConfig(BaseModel):
     """SSHplex main configuration."""
     version: str = __version__
     session_prefix: str = "sshplex"
-
-
-class NetBoxConfig(BaseModel):
-    """NetBox connection configuration."""
-    url: str = Field(..., description="NetBox instance URL")
-    token: str = Field(..., description="NetBox API token")
-    verify_ssl: bool = True
-    timeout: int = 30
-    default_filters: Dict[str, str] = Field(default_factory=dict)
 
 
 class LoggingConfig(BaseModel):
@@ -42,7 +50,7 @@ class UIConfig(BaseModel):
 class Proxy(BaseModel):
     """ImportProxies configuration with defaults."""
     name: str = Field("", description="Proxy name")
-    imports: list = Field([], description="List of imports that will use this proxy")
+    imports: list = Field(default_factory=list, description="List of imports that will use this proxy")
     host: str = Field("", description="Proxy host or ip")
     username: str = Field("", description="Proxy username")
     key_path: str = Field("", description="Proxy key")
@@ -109,6 +117,16 @@ class TmuxConfig(BaseModel):
         description="Split pattern for iTerm2 native: alternate, vertical, horizontal"
     )
 
+    @field_validator("backend")
+    @classmethod
+    def validate_backend_value(cls, value: str) -> str:
+        normalized = str(value or "").strip().lower()
+        if normalized not in SUPPORTED_MUX_BACKENDS:
+            raise ValueError(
+                f"Invalid backend: {value}. Must be one of: {list(SUPPORTED_MUX_BACKENDS)}"
+            )
+        return normalized
+
     def validate_backend_config(self) -> bool:
         """Validate backend configuration.
 
@@ -118,10 +136,9 @@ class TmuxConfig(BaseModel):
         import platform
 
         # Validate backend option
-        valid_backends = ["tmux", "iterm2-native"]
-        if self.backend not in valid_backends:
+        if self.backend not in SUPPORTED_MUX_BACKENDS:
             raise ValueError(
-                f"Invalid backend: {self.backend}. Must be one of: {valid_backends}"
+                f"Invalid backend: {self.backend}. Must be one of: {list(SUPPORTED_MUX_BACKENDS)}"
             )
 
         # Validate iTerm2 native mode on macOS only
@@ -146,11 +163,6 @@ class TmuxConfig(BaseModel):
         return True
 
 
-class AnsibleConfig(BaseModel):
-    """Ansible inventory configuration."""
-    inventory_paths: List[str] = Field(default_factory=list, description="List of paths to Ansible inventory YAML files")
-    default_filters: Dict[str, Any] = Field(default_factory=dict)
-
 class ConsulConfig(BaseModel):
     """Consul-specific configuration with defaults."""
     host: str = Field("consul.example.com", description="Consul host address")
@@ -164,7 +176,7 @@ class ConsulConfig(BaseModel):
 class SoTImportConfig(BaseModel):
     """Individual SoT import configuration."""
     name: str = Field(..., description="Unique name for this import")
-    type: str = Field(..., description="Provider type: static, netbox, ansible, consul, git")
+    type: str = Field(..., description=f"Provider type: {', '.join(SUPPORTED_SOT_PROVIDER_TYPES)}")
 
     # Static provider fields
     hosts: Optional[List[Dict[str, Any]]] = None
@@ -185,22 +197,71 @@ class SoTImportConfig(BaseModel):
     # Git provider fields
     repo_url: Optional[str] = None
     branch: Optional[str] = "main"
-    source_pattern: Optional[str] = None
-    path: Optional[str] = "hosts"
-    file_glob: Optional[str] = "**/*.y*ml"
+    source_pattern: Optional[str] = "hosts/**/*.y*ml"
     auto_pull: Optional[bool] = True
     pull_interval_seconds: Optional[int] = 300
     priority: Optional[int] = 100
     pull_strategy: Optional[str] = "ff-only"
     inventory_format: Optional[str] = "static"
 
+    @field_validator("type")
+    @classmethod
+    def validate_provider_type(cls, value: str) -> str:
+        normalized = str(value or "").strip().lower()
+        if normalized not in SUPPORTED_SOT_PROVIDER_TYPES:
+            raise ValueError(
+                f"Unsupported provider type '{value}'. "
+                f"Supported values: {list(SUPPORTED_SOT_PROVIDER_TYPES)}"
+            )
+        return normalized
+
+    @field_validator("pull_strategy")
+    @classmethod
+    def validate_pull_strategy(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return value
+        normalized = str(value).strip().lower()
+        if normalized and normalized != "ff-only":
+            raise ValueError("git pull_strategy only supports 'ff-only'")
+        return normalized or "ff-only"
+
+    @field_validator("inventory_format")
+    @classmethod
+    def validate_inventory_format(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return value
+        normalized = str(value).strip().lower()
+        if normalized not in SUPPORTED_GIT_INVENTORY_FORMATS:
+            raise ValueError(
+                f"Unsupported git inventory format '{value}'. "
+                f"Supported values: {list(SUPPORTED_GIT_INVENTORY_FORMATS)}"
+            )
+        return normalized
+
 class SoTConfig(BaseModel):
     """Source of Truth configuration."""
     providers: List[str] = Field(
-        default_factory=lambda: ["static"],
+        default_factory=list,
         description="List of SoT providers to use: static, netbox, ansible, consul, git",
     )
     import_: List[SoTImportConfig] = Field(alias='import', default_factory=list, description="List of import configurations")
+
+    @field_validator("providers")
+    @classmethod
+    def validate_enabled_providers(cls, value: List[str]) -> List[str]:
+        normalized: List[str] = []
+        for provider in value or []:
+            provider_name = str(provider or "").strip().lower()
+            if not provider_name:
+                continue
+            if provider_name not in SUPPORTED_SOT_PROVIDER_TYPES:
+                raise ValueError(
+                    f"Unsupported provider '{provider_name}'. "
+                    f"Supported values: {list(SUPPORTED_SOT_PROVIDER_TYPES)}"
+                )
+            if provider_name not in normalized:
+                normalized.append(provider_name)
+        return normalized
 
 
 class CacheConfig(BaseModel):
@@ -214,8 +275,6 @@ class Config(BaseModel):
     """Main SSHplex configuration model."""
     sshplex: SSHplexConfig = Field(default_factory=SSHplexConfig)
     sot: SoTConfig = Field(default_factory=SoTConfig)
-    netbox: Optional[NetBoxConfig] = None
-    ansible_inventory: Optional[AnsibleConfig] = None
     ssh: SSHConfig = Field(default_factory=SSHConfig)
     tmux: TmuxConfig = Field(default_factory=TmuxConfig)
     logging: LoggingConfig = Field(default_factory=LoggingConfig)

--- a/sshplex/lib/onboarding/wizard.py
+++ b/sshplex/lib/onboarding/wizard.py
@@ -14,7 +14,11 @@ from rich.prompt import Confirm, Prompt
 from rich.table import Table
 from rich.text import Text
 
-from ..config import Config
+from ..config import (
+    SUPPORTED_MUX_BACKENDS,
+    SUPPORTED_SOT_PROVIDER_TYPES,
+    Config,
+)
 from ..logger import get_logger
 
 
@@ -181,14 +185,18 @@ class OnboardingWizard:
             Provider configuration dict or None if cancelled
         """
         self.console.print("\n" + "─" * 60)
-        
+
         # Provider type selection
+        provider_descriptions = {
+            "static": "Static host list (manual entry)",
+            "netbox": "NetBox (infrastructure source of truth)",
+            "ansible": "Ansible inventory file",
+            "consul": "HashiCorp Consul (service discovery)",
+            "git": "Git repository inventory (static or ansible YAML)",
+        }
         provider_types = [
-            ("static", "Static host list (manual entry)"),
-            ("netbox", "NetBox (infrastructure source of truth)"),
-            ("ansible", "Ansible inventory file"),
-            ("consul", "HashiCorp Consul (service discovery)"),
-            ("git", "Git repository inventory (static or ansible YAML)"),
+            (provider_type, provider_descriptions.get(provider_type, provider_type))
+            for provider_type in SUPPORTED_SOT_PROVIDER_TYPES
         ]
         
         self.console.print("\n[bold]Select inventory source type:[/bold]")
@@ -197,20 +205,19 @@ class OnboardingWizard:
         
         choice = Prompt.ask("\nChoice", choices=[str(i) for i in range(1, len(provider_types) + 1)], default="1")
         provider_type = provider_types[int(choice) - 1][0]
-        
-        # Configure based on type
-        if provider_type == "static":
-            return self._configure_static()
-        elif provider_type == "netbox":
-            return self._configure_netbox()
-        elif provider_type == "ansible":
-            return self._configure_ansible()
-        elif provider_type == "consul":
-            return self._configure_consul()
-        elif provider_type == "git":
-            return self._configure_git()
-        
-        return None
+
+        configurators = {
+            "static": self._configure_static,
+            "netbox": self._configure_netbox,
+            "ansible": self._configure_ansible,
+            "consul": self._configure_consul,
+            "git": self._configure_git,
+        }
+        handler = configurators.get(provider_type)
+        if handler is None:
+            self.console.print(f"[red]Unsupported provider type: {provider_type}[/red]")
+            return None
+        return handler()
     
     def _configure_static(self) -> Optional[Dict[str, Any]]:
         """Configure static host provider."""
@@ -414,16 +421,12 @@ class OnboardingWizard:
                 except ValueError:
                     self.console.print(f"[red]Invalid interval: {interval_input}[/red]")
 
-        path, file_glob = self._split_source_pattern_legacy(source_pattern)
-
         config: Dict[str, Any] = {
             "name": name,
             "type": "git",
             "repo_url": repo_url,
             "branch": branch,
             "source_pattern": source_pattern,
-            "path": path,
-            "file_glob": file_glob,
             "inventory_format": inventory_format,
             "priority": priority,
             "auto_pull": auto_pull,
@@ -451,30 +454,6 @@ class OnboardingWizard:
 
         return config
 
-    @staticmethod
-    def _split_source_pattern_legacy(source_pattern: str) -> tuple[str, str]:
-        """Split source pattern into path/glob compatibility fields."""
-        normalized = str(source_pattern or "").strip().lstrip("/")
-        if not normalized:
-            return "hosts", "**/*.y*ml"
-
-        if normalized.endswith((".yml", ".yaml")):
-            return normalized, "**/*.y*ml"
-
-        wildcard_chars = {"*", "?", "["}
-        parts = normalized.split("/")
-        wildcard_index = -1
-        for idx, part in enumerate(parts):
-            if any(char in part for char in wildcard_chars):
-                wildcard_index = idx
-                break
-
-        if wildcard_index == -1:
-            return normalized, "**/*.y*ml"
-        if wildcard_index == 0:
-            return ".", normalized
-        return "/".join(parts[:wildcard_index]), "/".join(parts[wildcard_index:])
-    
     def _test_netbox_connection(self, config: Dict[str, Any]) -> bool:
         """Test NetBox connection."""
         self.logger.info(f"Testing NetBox connection to {config['url']}")
@@ -583,7 +562,7 @@ class OnboardingWizard:
             default_backend = "tmux" if tmux_installed else "iterm2-native"
             backend = Prompt.ask(
                 "Backend",
-                choices=["tmux", "iterm2-native"],
+                choices=list(SUPPORTED_MUX_BACKENDS),
                 default=default_backend,
             )
             return backend
@@ -684,7 +663,7 @@ class OnboardingWizard:
                     cfg = provider.get("config", {}) or {}
                     details = f"{cfg.get('scheme', 'http')}://{cfg.get('host', 'localhost')}:{cfg.get('port', 8500)}"
                 elif provider_type == "git":
-                    details = str(provider.get("source_pattern", provider.get("path", "")))
+                    details = str(provider.get("source_pattern", ""))
 
                 provider_table.add_row(provider_name, provider_type, details)
 

--- a/sshplex/lib/sot/base.py
+++ b/sshplex/lib/sot/base.py
@@ -7,14 +7,65 @@ from typing import Any, Dict, List, Optional
 class Host:
     """Simple host data structure."""
 
-    def __init__(self, name: str, ip: str, **kwargs: Any) -> None:
+    _RESERVED_METADATA_KEYS = {"name", "ip", "metadata"}
+
+    def __init__(
+        self,
+        name: str,
+        ip: str,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> None:
         self.name = name
         self.ip = ip
-        self.metadata = kwargs
+        self.metadata: Dict[str, Any] = {}
 
-        # Set additional attributes from kwargs for easy access
-        for key, value in kwargs.items():
+        if metadata:
+            self.update_metadata(metadata)
+        if kwargs:
+            self.update_metadata(kwargs)
+
+    def update_metadata(self, values: Dict[str, Any]) -> None:
+        """Merge metadata values and mirror them as instance attributes."""
+        for raw_key, value in values.items():
+            key = str(raw_key)
+            if key in self._RESERVED_METADATA_KEYS:
+                continue
+            self.metadata[key] = value
             setattr(self, key, value)
+
+    def merge_metadata(self, values: Dict[str, Any]) -> None:
+        """Compatibility helper to merge metadata values in-place."""
+        self.update_metadata(values)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize host object to cache-friendly dictionary."""
+        return {
+            "name": self.name,
+            "ip": self.ip,
+            "metadata": dict(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Dict[str, Any]) -> "Host":
+        """Create host object from serialized dictionary payload."""
+        metadata = payload.get("metadata", {})
+        if not isinstance(metadata, dict):
+            metadata = {}
+
+        extras = {
+            key: value
+            for key, value in payload.items()
+            if key not in cls._RESERVED_METADATA_KEYS
+        }
+        merged_metadata = dict(metadata)
+        merged_metadata.update(extras)
+
+        return cls(
+            name=str(payload["name"]),
+            ip=str(payload["ip"]),
+            metadata=merged_metadata,
+        )
 
     def __str__(self) -> str:
         return f"{self.name} ({self.ip})"

--- a/sshplex/lib/sot/factory.py
+++ b/sshplex/lib/sot/factory.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import json
+import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Any
 
 from ..cache import HostCache
+from ..config import SUPPORTED_SOT_PROVIDER_TYPES
 from ..logger import get_logger
 from .ansible import AnsibleProvider
 from .base import Host, SoTProvider
@@ -40,7 +43,63 @@ class SoTFactory:
             # Use default cache settings if not configured
             self.cache = HostCache()
 
-        self._cached_hosts: list[Host] | None = None
+        self._cached_hosts_by_key: dict[str, list[Host]] = {}
+        self._cache_lock = threading.RLock()
+        self._provider_creators: dict[str, str] = {
+            "static": "_create_static_provider",
+            "netbox": "_create_netbox_provider_from_import",
+            "ansible": "_create_ansible_provider_from_import",
+            "consul": "_create_consul_provider",
+            "git": "_create_git_provider",
+        }
+
+    @staticmethod
+    def _normalize_filters(additional_filters: dict[str, Any] | None) -> dict[str, Any]:
+        """Normalize optional host filters to a deterministic dictionary."""
+        if not additional_filters:
+            return {}
+        return {str(key): value for key, value in additional_filters.items()}
+
+    def _build_cache_key(self, additional_filters: dict[str, Any] | None) -> str:
+        """Build a deterministic cache key based on active filters."""
+        normalized = self._normalize_filters(additional_filters)
+        if not normalized:
+            return "default"
+        try:
+            return json.dumps(normalized, sort_keys=True, separators=(",", ":"), default=str)
+        except TypeError:
+            fallback = {key: str(value) for key, value in normalized.items()}
+            return json.dumps(fallback, sort_keys=True, separators=(",", ":"))
+
+    def _get_enabled_provider_types(self, configured_imports: list[Any]) -> set[str]:
+        """Resolve enabled provider types from config or infer from imports."""
+        configured_types = {
+            str(provider_type).strip()
+            for provider_type in (getattr(self.config.sot, "providers", []) or [])
+            if str(provider_type).strip()
+        }
+        unknown_configured = configured_types.difference(SUPPORTED_SOT_PROVIDER_TYPES)
+        if unknown_configured:
+            self.logger.warning(
+                "Ignoring unknown provider types from sot.providers: "
+                f"{sorted(unknown_configured)}"
+            )
+        configured_types = configured_types.intersection(SUPPORTED_SOT_PROVIDER_TYPES)
+        if configured_types:
+            return configured_types
+
+        inferred_types = {
+            str(getattr(import_config, "type", "")).strip()
+            for import_config in configured_imports
+            if str(getattr(import_config, "type", "")).strip()
+        }
+        inferred_types = inferred_types.intersection(SUPPORTED_SOT_PROVIDER_TYPES)
+        if inferred_types:
+            self.logger.info(
+                "No explicit sot.providers configured; inferred provider types from imports: "
+                f"{sorted(inferred_types)}"
+            )
+        return inferred_types
 
     def initialize_providers(self) -> bool:
         """Initialize all configured SoT providers from import configurations.
@@ -58,38 +117,10 @@ class SoTFactory:
             self.logger.error("No import configurations found in sot.import")
             return False
 
-        sot_config = self.config.sot
-        providers_explicitly_set = True
-        if hasattr(sot_config, "model_fields_set"):
-            providers_explicitly_set = "providers" in getattr(
-                sot_config,
-                "model_fields_set",
-                set(),
-            )
-
-        provider_types_source = "config"
-        enabled_provider_types = {
-            str(provider_type).strip()
-            for provider_type in (getattr(sot_config, "providers", []) or [])
-            if str(provider_type).strip()
-        }
-
-        if not providers_explicitly_set:
-            provider_types_source = "imports"
-            enabled_provider_types = {
-                str(getattr(import_config, "type", "")).strip()
-                for import_config in configured_imports
-                if str(getattr(import_config, "type", "")).strip()
-            }
-            if enabled_provider_types:
-                self.logger.info(
-                    "No explicit sot.providers configured; inferred enabled provider "
-                    f"types from imports: {sorted(enabled_provider_types)}"
-                )
-
+        enabled_provider_types = self._get_enabled_provider_types(configured_imports)
         if enabled_provider_types:
             self.logger.info(
-                f"Enabled provider types from {provider_types_source}: {sorted(enabled_provider_types)}"
+                f"Enabled provider types: {sorted(enabled_provider_types)}"
             )
 
         for import_config in configured_imports:
@@ -104,21 +135,26 @@ class SoTFactory:
                     continue
 
                 attempted_count += 1
-                provider: SoTProvider | None = None
-
-                if import_type == "static":
-                    provider = self._create_static_provider(import_config)
-                elif import_type == "netbox":
-                    provider = self._create_netbox_provider_from_import(import_config)
-                elif import_type == "ansible":
-                    provider = self._create_ansible_provider_from_import(import_config)
-                elif import_type == "consul":
-                    provider = self._create_consul_provider(import_config)
-                elif import_type == "git":
-                    provider = self._create_git_provider(import_config)
-                else:
-                    self.logger.error(f"Unknown SoT provider type: {import_type}")
+                if import_type not in SUPPORTED_SOT_PROVIDER_TYPES:
+                    self.logger.error(
+                        f"Unknown SoT provider type: {import_type}. "
+                        f"Supported types: {list(SUPPORTED_SOT_PROVIDER_TYPES)}"
+                    )
                     continue
+
+                creator_name = self._provider_creators.get(import_type)
+                if creator_name is None:
+                    self.logger.error(f"No provider creator registered for type '{import_type}'")
+                    continue
+
+                creator = getattr(self, creator_name, None)
+                if creator is None:
+                    self.logger.error(
+                        f"Provider creator method '{creator_name}' is missing for type '{import_type}'"
+                    )
+                    continue
+
+                provider: SoTProvider | None = creator(import_config)
 
                 if provider and provider.connect():
                     self.providers.append(provider)
@@ -236,18 +272,32 @@ class SoTFactory:
 
         return provider
 
-    def _load_hosts_from_cache(self, force_refresh: bool) -> list[Host] | None:
+    def _load_hosts_from_cache(
+        self,
+        force_refresh: bool,
+        additional_filters: dict[str, Any] | None,
+    ) -> list[Host] | None:
         """Load hosts from memory/cache when refresh is not requested."""
-        if not force_refresh and self._cached_hosts is not None:
-            self.logger.debug("Returning already loaded hosts from memory")
-            return self._cached_hosts
+        if force_refresh:
+            return None
 
-        if not force_refresh:
-            cached_hosts = self.cache.load_hosts()
-            if cached_hosts is not None:
-                self.logger.info(f"Loaded {len(cached_hosts)} hosts from cache")
-                self._cached_hosts = cached_hosts
-                return cached_hosts
+        cache_key = self._build_cache_key(additional_filters)
+        with self._cache_lock:
+            memory_hosts = self._cached_hosts_by_key.get(cache_key)
+            if memory_hosts is not None:
+                self.logger.debug(f"Returning hosts from memory cache key '{cache_key}'")
+                return memory_hosts
+
+        # Disk cache is only used for unfiltered host sets.
+        if cache_key != "default":
+            return None
+
+        cached_hosts = self.cache.load_hosts()
+        if cached_hosts is not None:
+            self.logger.info(f"Loaded {len(cached_hosts)} hosts from cache")
+            with self._cache_lock:
+                self._cached_hosts_by_key[cache_key] = cached_hosts
+            return cached_hosts
 
         return None
 
@@ -258,14 +308,22 @@ class SoTFactory:
         fetch_mode: str,
     ) -> None:
         """Persist retrieved hosts in cache and memory."""
+        cache_key = self._build_cache_key(additional_filters)
+        with self._cache_lock:
+            self._cached_hosts_by_key[cache_key] = hosts
+
+        # Keep on-disk cache canonical for unfiltered results only.
+        if cache_key != "default":
+            return
+
         provider_info = {
             'provider_count': len(self.providers),
             'provider_names': self.get_provider_names(),
             'filters_applied': additional_filters or {},
             'fetch_mode': fetch_mode,
+            'cache_key': cache_key,
         }
         self.cache.save_hosts(hosts, provider_info)
-        self._cached_hosts = hosts
 
     def _deduplicate_hosts(self, hosts: list[Host]) -> list[Host]:
         """Deduplicate hosts and merge metadata/source information."""
@@ -279,10 +337,10 @@ class SoTFactory:
                 unique_hosts[key] = host
                 continue
 
-            existing.metadata.update(host.metadata)
-
             existing_sources = existing.metadata.get('sources', [])
             incoming_sources = host.metadata.get('sources', [])
+
+            existing.merge_metadata(host.metadata)
 
             if isinstance(existing_sources, str):
                 existing_sources = [existing_sources]
@@ -306,7 +364,7 @@ class SoTFactory:
                     merged_sources.append(source_text)
 
             if merged_sources:
-                existing.metadata['sources'] = merged_sources
+                existing.merge_metadata({'sources': merged_sources})
 
         return list(unique_hosts.values())
 
@@ -320,7 +378,7 @@ class SoTFactory:
         Returns:
             Combined list of hosts from all providers
         """
-        cached_hosts = self._load_hosts_from_cache(force_refresh)
+        cached_hosts = self._load_hosts_from_cache(force_refresh, additional_filters)
         if cached_hosts is not None:
             return cached_hosts
 
@@ -366,7 +424,7 @@ class SoTFactory:
         Returns:
             Combined list of hosts from all providers
         """
-        cached_hosts = self._load_hosts_from_cache(force_refresh)
+        cached_hosts = self._load_hosts_from_cache(force_refresh, additional_filters)
         if cached_hosts is not None:
             return cached_hosts
 
@@ -450,12 +508,6 @@ class SoTFactory:
         import_filters = getattr(provider, 'import_filters', None)
         if import_filters:
             filters.update(import_filters)
-        elif isinstance(provider, NetBoxProvider) and self.config.netbox:
-            # Fallback to old configuration structure if available
-            filters.update(self.config.netbox.default_filters)
-        elif isinstance(provider, AnsibleProvider) and self.config.ansible_inventory:
-            # Fallback to old configuration structure if available
-            filters.update(self.config.ansible_inventory.default_filters)
 
         # Merge additional filters
         if additional_filters:
@@ -557,7 +609,8 @@ class SoTFactory:
         Returns:
             True if cache was cleared successfully, False otherwise
         """
-        self._cached_hosts = None
+        with self._cache_lock:
+            self._cached_hosts_by_key.clear()
         return self.cache.clear_cache()
 
     def is_cache_valid(self) -> bool:
@@ -604,22 +657,7 @@ class SoTFactory:
         if not configured_imports:
             return initialized
 
-        enabled_provider_types = {
-            str(provider_type).strip()
-            for provider_type in (getattr(self.config.sot, "providers", []) or [])
-            if str(provider_type).strip()
-        }
-
-        providers_explicitly_set = True
-        if hasattr(self.config.sot, "model_fields_set"):
-            providers_explicitly_set = "providers" in getattr(self.config.sot, "model_fields_set", set())
-
-        if not providers_explicitly_set:
-            enabled_provider_types = {
-                str(getattr(import_config, "type", "")).strip()
-                for import_config in configured_imports
-                if str(getattr(import_config, "type", "")).strip()
-            }
+        enabled_provider_types = self._get_enabled_provider_types(configured_imports)
 
         for import_config in configured_imports:
             import_type = str(getattr(import_config, "type", "")).strip()

--- a/sshplex/lib/sot/git.py
+++ b/sshplex/lib/sot/git.py
@@ -32,9 +32,10 @@ class GitProvider(SoTProvider):
         self.provider_name = self.name
         self.repo_url = str(getattr(import_config, "repo_url", "") or "").strip()
         self.branch = str(getattr(import_config, "branch", "main") or "main").strip() or "main"
-        self.source_pattern = str(getattr(import_config, "source_pattern", "") or "").strip()
-        self.source_path = str(getattr(import_config, "path", "hosts") or "hosts").strip() or "hosts"
-        self.file_glob = str(getattr(import_config, "file_glob", "**/*.y*ml") or "**/*.y*ml").strip() or "**/*.y*ml"
+        self.source_pattern = (
+            str(getattr(import_config, "source_pattern", "hosts/**/*.y*ml") or "hosts/**/*.y*ml")
+            .strip()
+        )
         self.auto_pull = bool(getattr(import_config, "auto_pull", True))
         self.pull_interval_seconds = int(getattr(import_config, "pull_interval_seconds", 300) or 300)
         self.priority = int(getattr(import_config, "priority", 100) or 100)
@@ -191,16 +192,10 @@ class GitProvider(SoTProvider):
         if not self._ensure_repository():
             return []
 
-        if self.source_pattern:
-            files = self._resolve_source_pattern_files(self.source_pattern)
-        else:
-            root = self.repo_dir / self.source_path
-            files = self._resolve_source_files(root)
+        files = self._resolve_source_pattern_files(self.source_pattern)
         if not files:
-            location = self.source_pattern if self.source_pattern else self.source_path
-            selection = self.source_pattern if self.source_pattern else self.file_glob
             self.logger.warning(
-                f"Git provider '{self.name}' found no host files for source '{location}' matching '{selection}'"
+                f"Git provider '{self.name}' found no host files for source pattern '{self.source_pattern}'"
             )
             return []
 
@@ -320,16 +315,6 @@ class GitProvider(SoTProvider):
         if completed.returncode != 0:
             return ""
         return (completed.stdout or "").strip()
-
-    def _resolve_source_files(self, root: Path) -> list[Path]:
-        """Resolve YAML files to parse for host data."""
-        if root.is_file():
-            return [root]
-        if not root.exists() or not root.is_dir():
-            return []
-
-        matched = [path for path in root.glob(self.file_glob) if path.is_file()]
-        return sorted(matched)
 
     def _resolve_source_pattern_files(self, source_pattern: str) -> list[Path]:
         """Resolve source pattern directly from repository root."""
@@ -474,9 +459,7 @@ class GitProvider(SoTProvider):
                 unique[key] = host
                 continue
 
-            existing.metadata.update(host.metadata)
-            for metadata_key, metadata_value in host.metadata.items():
-                setattr(existing, metadata_key, metadata_value)
+            existing.merge_metadata(host.metadata)
 
             existing_sources = existing.metadata.get("sources", []) or []
             incoming_sources = host.metadata.get("sources", []) or []
@@ -485,7 +468,7 @@ class GitProvider(SoTProvider):
                 for source in [*existing_sources, *incoming_sources]:
                     if source not in merged_sources:
                         merged_sources.append(source)
-                existing.metadata["sources"] = merged_sources
+                existing.merge_metadata({"sources": merged_sources})
 
         return list(unique.values())
 

--- a/sshplex/lib/sot/netbox.py
+++ b/sshplex/lib/sot/netbox.py
@@ -2,10 +2,17 @@
 
 from typing import Any, Dict, List, Optional
 
-import pynetbox  # type: ignore
-
 from ..logger import get_logger
 from .base import Host, SoTProvider
+
+
+def _import_pynetbox() -> Any | None:
+    """Import pynetbox lazily so optional dependency errors stay isolated."""
+    try:
+        import pynetbox  # type: ignore
+    except ImportError:
+        return None
+    return pynetbox
 
 
 class NetBoxProvider(SoTProvider):
@@ -37,6 +44,14 @@ class NetBoxProvider(SoTProvider):
         """
         try:
             self.logger.info(f"Connecting to NetBox at {self.url}")
+
+            pynetbox = _import_pynetbox()
+            if pynetbox is None:
+                self.logger.error(
+                    "NetBox provider requires 'pynetbox' package. "
+                    "Install with: pip install sshplex or pip install pynetbox"
+                )
+                return False
 
             self.api = pynetbox.api(
                 url=self.url,

--- a/sshplex/lib/ui/config_editor.py
+++ b/sshplex/lib/ui/config_editor.py
@@ -24,7 +24,14 @@ from textual.widgets import (
     TextArea,
 )
 
-from ..config import Config, get_default_config_path
+from ..config import (
+    MUX_BACKEND_LABELS,
+    SOT_PROVIDER_LABELS,
+    SUPPORTED_MUX_BACKENDS,
+    SUPPORTED_SOT_PROVIDER_TYPES,
+    Config,
+    get_default_config_path,
+)
 
 
 def _form_field(
@@ -863,6 +870,18 @@ class ConfigEditorScreen(ModalScreen[bool]):
         return ordered + extras
 
     def compose(self) -> ComposeResult:
+        enabled_provider_values = {
+            str(provider).strip()
+            for provider in (getattr(self.config.sot, "providers", []) or [])
+            if str(provider).strip()
+        }
+        if not enabled_provider_values:
+            enabled_provider_values = {
+                str(getattr(imp, "type", "")).strip()
+                for imp in (getattr(self.config.sot, "import_", []) or [])
+                if str(getattr(imp, "type", "")).strip()
+            }
+
         with Vertical(id="config-editor-dialog"):
             yield Static("SSHplex Configuration Editor", id="editor-title")
 
@@ -1081,10 +1100,13 @@ class ConfigEditorScreen(ModalScreen[bool]):
                             "cfg-mux-backend",
                             "Backend",
                             Select(
-                                [("tmux", "tmux"), ("iTerm2 Native", "iterm2-native")],
+                                [
+                                    (MUX_BACKEND_LABELS.get(backend, backend), backend)
+                                    for backend in SUPPORTED_MUX_BACKENDS
+                                ],
                                 value=self._safe_select_initial(
                                     str(getattr(self.config.tmux, "backend", "tmux")),
-                                    ["tmux", "iterm2-native"],
+                                    list(SUPPORTED_MUX_BACKENDS),
                                     "tmux",
                                 ),
                             ),
@@ -1145,11 +1167,13 @@ class ConfigEditorScreen(ModalScreen[bool]):
                     yield Static("Providers", classes="section-header")
                     yield Static("Enable the data sources SSHplex should load.", classes="form-description")
                     with Horizontal(id="sources-providers"):
-                        yield Checkbox("Static", value="static" in self.config.sot.providers, id="cfg-sot-provider-static", compact=True)
-                        yield Checkbox("NetBox", value="netbox" in self.config.sot.providers, id="cfg-sot-provider-netbox", compact=True)
-                        yield Checkbox("Ansible", value="ansible" in self.config.sot.providers, id="cfg-sot-provider-ansible", compact=True)
-                        yield Checkbox("Consul", value="consul" in self.config.sot.providers, id="cfg-sot-provider-consul", compact=True)
-                        yield Checkbox("Git", value="git" in self.config.sot.providers, id="cfg-sot-provider-git", compact=True)
+                        for provider in SUPPORTED_SOT_PROVIDER_TYPES:
+                            yield Checkbox(
+                                SOT_PROVIDER_LABELS.get(provider, provider.title()),
+                                value=provider in enabled_provider_values,
+                                id=f"cfg-sot-provider-{provider}",
+                                compact=True,
+                            )
                     with Horizontal(classes="list-buttons"):
                         yield Button("All", id="btn-providers-all", variant="default")
                         yield Button("None", id="btn-providers-none", variant="default")
@@ -1254,7 +1278,7 @@ class ConfigEditorScreen(ModalScreen[bool]):
         container = self.query_one("#mux-backend-fields", Vertical)
         backend = self._safe_select_initial(
             str(getattr(self.config.tmux, "backend", "tmux")),
-            ["tmux", "iterm2-native"],
+            list(SUPPORTED_MUX_BACKENDS),
             "tmux",
         )
         self._mux_backend = backend
@@ -1396,7 +1420,7 @@ class ConfigEditorScreen(ModalScreen[bool]):
         name = imp.name if imp else ""
         imp_type = self._safe_select_initial(
             str(getattr(imp, "type", "static")) if imp else "static",
-            ["static", "netbox", "ansible", "consul", "git"],
+            list(SUPPORTED_SOT_PROVIDER_TYPES),
             "static",
         )
         self._import_types[str(idx)] = imp_type
@@ -1404,7 +1428,7 @@ class ConfigEditorScreen(ModalScreen[bool]):
         header = Horizontal(
             Input(value=name, placeholder="Import name", id=f"import-{idx}-name", classes="import-name"),
             Select(
-                [(v, v) for v in ["static", "netbox", "ansible", "consul", "git"]],
+                [(v, v) for v in SUPPORTED_SOT_PROVIDER_TYPES],
                 value=imp_type,
                 id=f"import-{idx}-type",
                 classes="import-type",
@@ -1431,48 +1455,6 @@ class ConfigEditorScreen(ModalScreen[bool]):
     def _import_form_field(self, field_id: str, label: str, description: str, widget: Any) -> Vertical:
         """Build an import field with label + helper text above input."""
         return _form_field(field_id, label, widget, description)
-
-    @staticmethod
-    def _compose_git_source_pattern(path: str, file_glob: str) -> str:
-        """Build a single source pattern from legacy path + glob values."""
-        clean_path = str(path or "").strip().strip("/")
-        clean_glob = str(file_glob or "").strip().strip("/")
-
-        if clean_path.endswith((".yml", ".yaml")):
-            return clean_path
-        if clean_path and clean_glob:
-            return f"{clean_path}/{clean_glob}"
-        if clean_path:
-            return clean_path
-        if clean_glob:
-            return clean_glob
-        return "hosts/**/*.y*ml"
-
-    @staticmethod
-    def _split_git_source_pattern(source_pattern: str) -> tuple[str, str]:
-        """Split a source pattern into legacy path + glob fields."""
-        normalized = str(source_pattern or "").strip().lstrip("/")
-        if not normalized:
-            return "hosts", "**/*.y*ml"
-
-        if normalized.endswith((".yml", ".yaml")):
-            return normalized, "**/*.y*ml"
-
-        wildcard_chars = {"*", "?", "["}
-        parts = normalized.split("/")
-        wildcard_index = -1
-        for idx, part in enumerate(parts):
-            if any(char in part for char in wildcard_chars):
-                wildcard_index = idx
-                break
-
-        if wildcard_index == -1:
-            return normalized, "**/*.y*ml"
-
-        if wildcard_index == 0:
-            return ".", normalized
-
-        return "/".join(parts[:wildcard_index]), "/".join(parts[wildcard_index:])
 
     def _make_import_type_fields(self, idx: int, imp_type: str, imp: Any = None) -> list:
         """Generate type-specific fields for an import item."""
@@ -1621,12 +1603,9 @@ class ConfigEditorScreen(ModalScreen[bool]):
             fields.append(Static("Git settings", classes="form-label"))
             source_pattern = "hosts/**/*.y*ml"
             if imp is not None:
-                source_pattern = str(getattr(imp, "source_pattern", "") or "").strip()
-                if not source_pattern:
-                    source_pattern = self._compose_git_source_pattern(
-                        str(getattr(imp, "path", "hosts") or "hosts"),
-                        str(getattr(imp, "file_glob", "**/*.y*ml") or "**/*.y*ml"),
-                    )
+                source_pattern = str(
+                    getattr(imp, "source_pattern", "hosts/**/*.y*ml") or "hosts/**/*.y*ml"
+                ).strip()
 
             fields.append(_form_row(
                 self._import_form_field(
@@ -1800,7 +1779,7 @@ class ConfigEditorScreen(ModalScreen[bool]):
 
     def _set_all_providers(self, enabled: bool) -> None:
         """Toggle all provider checkboxes on/off."""
-        for provider in ["static", "netbox", "ansible", "consul", "git"]:
+        for provider in SUPPORTED_SOT_PROVIDER_TYPES:
             with contextlib.suppress(Exception):
                 checkbox = self.query_one(f"#cfg-sot-provider-{provider}", Checkbox)
                 checkbox.value = enabled
@@ -2170,7 +2149,7 @@ class ConfigEditorScreen(ModalScreen[bool]):
     def _collect_enabled_providers(self) -> List[str]:
         """Collect enabled SoT providers from checkbox controls."""
         enabled: List[str] = []
-        for provider in ["static", "netbox", "ansible", "consul", "git"]:
+        for provider in SUPPORTED_SOT_PROVIDER_TYPES:
             try:
                 if self.query_one(f"#cfg-sot-provider-{provider}", Checkbox).value:
                     enabled.append(provider)
@@ -2263,9 +2242,6 @@ class ConfigEditorScreen(ModalScreen[bool]):
                     f"import-{i}-git_source_pattern",
                     "hosts/**/*.y*ml",
                 )
-                legacy_path, legacy_glob = self._split_git_source_pattern(entry["source_pattern"])
-                entry["path"] = legacy_path
-                entry["file_glob"] = legacy_glob
                 entry["inventory_format"] = self._get_select_value(f"import-{i}-git_inventory_format", "static")
                 entry["pull_strategy"] = "ff-only"
                 entry["auto_pull"] = self._get_select_value(f"import-{i}-git_auto_pull", "true") == "true"

--- a/sshplex/lib/ui/host_selector.py
+++ b/sshplex/lib/ui/host_selector.py
@@ -12,7 +12,7 @@ from textual.app import App, ComposeResult, SystemCommand
 from textual.binding import Binding
 from textual.containers import Container, Vertical
 from textual.reactive import reactive
-from textual.screen import Screen
+from textual.screen import ModalScreen, Screen
 from textual.widgets import (
     DataTable,
     Footer,
@@ -37,7 +37,7 @@ from .config_editor import ConfigEditorScreen
 from .session_manager import ITerm2SessionManager, TmuxSessionManager
 
 
-class LoadingScreen(Screen):
+class LoadingScreen(ModalScreen[None]):
     """Modal screen that displays loading progress while refreshing data sources."""
 
     CSS = """
@@ -274,6 +274,7 @@ class HostSelector(App):
         self.latest_native_session_name: Optional[str] = None
         self.native_sessions_created_count = 0
         self._log_max_lines = 1000
+        self._host_load_lock = asyncio.Lock()
 
     def compose(self) -> ComposeResult:
         """Create the UI layout."""
@@ -409,14 +410,19 @@ class HostSelector(App):
 
     def show_loading_screen(self, message: str = "🔄 Refreshing Data Sources", status: str = "Initializing...") -> None:
         """Show the loading screen modal."""
+        if self.loading_screen is not None:
+            self.hide_loading_screen()
         self.loading_screen = LoadingScreen(message=message, status=status)
         self.push_screen(self.loading_screen)
 
     def hide_loading_screen(self) -> None:
         """Hide the loading screen modal."""
-        if self.loading_screen:
-            self.pop_screen()
-            self.loading_screen = None
+        if self.loading_screen is None:
+            return
+        loading_screen = self.loading_screen
+        self.loading_screen = None
+        with contextlib.suppress(Exception):
+            loading_screen.dismiss(None)
 
     def update_cache_display(self) -> None:
         """Update the cache display with current cache information."""
@@ -464,6 +470,11 @@ class HostSelector(App):
                 self.log_message(f"Warning: Could not update loading status: {e}", level="warning")
 
     async def load_hosts(self, force_refresh: bool = False) -> None:
+        """Load hosts from all configured SoT providers with single-flight protection."""
+        async with self._host_load_lock:
+            await self._load_hosts_impl(force_refresh=force_refresh)
+
+    async def _load_hosts_impl(self, force_refresh: bool = False) -> None:
         """Load hosts from all configured SoT providers with caching support.
 
         Args:

--- a/sshplex/lib/ui/session_manager.py
+++ b/sshplex/lib/ui/session_manager.py
@@ -487,25 +487,20 @@ class TmuxSessionManager(ModalScreen):
         self.table.add_column("Windows", width=7)
         self.table.add_column("Panes", width=6)
 
-        # Load sessions first
-        self.load_sessions()
+        # Load sessions in background to keep UI responsive
+        self.run_worker(self.load_sessions(), name="tmux_load_sessions")
 
         # Focus on the table after loading data
         self.table.focus()
 
-        # Move cursor to first row if we have sessions
-        if self.sessions:
-            self.table.move_cursor(row=0)
+        # Cursor is moved after async load completes
 
-    def load_sessions(self) -> None:
-        """Load tmux sessions from the server."""
+    def _load_sessions_blocking(self) -> tuple[list[TmuxSession], str | None]:
+        """Collect tmux sessions using blocking libtmux calls."""
         try:
-            # Initialize tmux server
-            self.tmux_server = libtmux.Server()
-
-            # Get all sessions (list_sessions is removed in newer libtmux)
-            tmux_sessions = list(getattr(self.tmux_server, "sessions", []))
-            self.sessions.clear()
+            tmux_server = libtmux.Server()
+            tmux_sessions = list(getattr(tmux_server, "sessions", []))
+            sessions: list[TmuxSession] = []
 
             for session in tmux_sessions:
                 # Get window count safely
@@ -545,6 +540,7 @@ class TmuxSessionManager(ModalScreen):
                     result = session.cmd('display-message', '-p', '#{session_created}')
                     if result and hasattr(result, 'stdout') and result.stdout:
                         import datetime
+
                         timestamp = int(result.stdout[0])
                         created_dt = datetime.datetime.fromtimestamp(timestamp)
                         created = created_dt.strftime("%Y-%m-%d %H:%M:%S")
@@ -586,30 +582,42 @@ class TmuxSessionManager(ModalScreen):
                 else:
                     active_cmd = "-"
 
-                tmux_session = TmuxSession(
-                    name=session.session_name or "Unknown",
-                    session_id=session.session_id or "Unknown",
-                    created=created,
-                    age=age,
-                    windows=window_count,
-                    panes=pane_count,
-                    clients=clients,
-                    active_cmd=active_cmd,
-                    broadcast=broadcast_on
+                sessions.append(
+                    TmuxSession(
+                        name=session.session_name or "Unknown",
+                        session_id=session.session_id or "Unknown",
+                        created=created,
+                        age=age,
+                        windows=window_count,
+                        panes=pane_count,
+                        clients=clients,
+                        active_cmd=active_cmd,
+                        broadcast=broadcast_on,
+                    )
                 )
-                self.sessions.append(tmux_session)
 
-            # Populate table
-            self.populate_table()
-
-            self.logger.info(f"SSHplex: Loaded {len(self.sessions)} tmux sessions")
+            return sessions, None
 
         except Exception as e:
-            self.logger.error(f"SSHplex: Failed to load tmux sessions: {e}")
-            # Show error in table
+            return [], str(e)
+
+    async def load_sessions(self) -> None:
+        """Load tmux sessions from the server without blocking the UI thread."""
+        sessions, error = await asyncio.to_thread(self._load_sessions_blocking)
+        self.sessions = sessions
+
+        if error:
+            self.logger.error(f"SSHplex: Failed to load tmux sessions: {error}")
             if self.table is not None:
                 self.table.clear()
-                self.table.add_row("-", "tmux error", "-", "-", "-", str(e), "0", "0")
+                self.table.add_row("-", "tmux error", "-", "-", "-", error, "0", "0")
+            return
+
+        self.populate_table()
+        if self.table and self.sessions and self.table.cursor_row < 0:
+            self.table.move_cursor(row=0)
+
+        self.logger.info(f"SSHplex: Loaded {len(self.sessions)} tmux sessions")
 
     def populate_table(self) -> None:
         """Populate the table with session data."""
@@ -759,7 +767,7 @@ class TmuxSessionManager(ModalScreen):
         except Exception as e:
             self.logger.error(f"SSHplex: Failed to kill session: {e}")
         finally:
-            self.load_sessions()
+            self.run_worker(self.load_sessions(), name="tmux_reload_after_kill")
 
     def on_key(self, event: Any) -> None:
         """Ensure key shortcuts work while table has focus."""
@@ -780,9 +788,7 @@ class TmuxSessionManager(ModalScreen):
     def action_refresh_sessions(self) -> None:
         """Refresh the session list."""
         self.logger.info("SSHplex: Refreshing tmux sessions")
-        self.load_sessions()
-        if self.table and self.sessions and self.table.cursor_row < 0:
-            self.table.move_cursor(row=0)
+        self.run_worker(self.load_sessions(), name="tmux_refresh_sessions")
 
     def action_close_manager(self) -> None:
         """Close the session manager."""
@@ -834,7 +840,7 @@ class TmuxSessionManager(ModalScreen):
                     status_widget.update("📡 Broadcast: OFF")
 
                 # Refresh table to update per-session broadcast column
-                self.load_sessions()
+                self.run_worker(self.load_sessions(), name="tmux_reload_after_broadcast")
 
             except Exception as e:
                 self.logger.error(f"SSHplex: Failed to toggle broadcast for session '{session.name}': {e}")
@@ -853,11 +859,8 @@ class TmuxSessionManager(ModalScreen):
 
             try:
                 # Find the tmux session
-                if self.tmux_server is None:
-                    self.logger.error("SSHplex: tmux server not initialized")
-                    return
-
-                tmux_session = self.tmux_server.find_where({"session_name": session.name})
+                self.tmux_server = libtmux.Server()
+                tmux_session = self._find_tmux_session(session.name)
                 if not tmux_session:
                     self.logger.error(f"SSHplex: Session '{session.name}' not found")
                     return
@@ -879,7 +882,7 @@ class TmuxSessionManager(ModalScreen):
                         self.logger.info(f"SSHplex: Created new pane in session '{session.name}'")
 
                         # Refresh session list to update window/pane count
-                        self.load_sessions()
+                        self.run_worker(self.load_sessions(), name="tmux_reload_after_create_pane")
                     else:
                         self.logger.error(f"SSHplex: Failed to create pane in session '{session.name}'")
                 else:
@@ -902,11 +905,8 @@ class TmuxSessionManager(ModalScreen):
 
             try:
                 # Find the tmux session
-                if self.tmux_server is None:
-                    self.logger.error("SSHplex: tmux server not initialized")
-                    return
-
-                tmux_session = self.tmux_server.find_where({"session_name": session.name})
+                self.tmux_server = libtmux.Server()
+                tmux_session = self._find_tmux_session(session.name)
                 if not tmux_session:
                     self.logger.error(f"SSHplex: Session '{session.name}' not found")
                     return
@@ -927,7 +927,7 @@ class TmuxSessionManager(ModalScreen):
                     self.logger.info(f"SSHplex: Created new window in session '{session.name}'")
 
                     # Refresh session list to update window count
-                    self.load_sessions()
+                    self.run_worker(self.load_sessions(), name="tmux_reload_after_create_window")
                 else:
                     self.logger.error(f"SSHplex: Failed to create window in session '{session.name}'")
 

--- a/sshplex/sshplex_connector.py
+++ b/sshplex/sshplex_connector.py
@@ -1,11 +1,11 @@
 """SSHplex Connector - SSH connections and multiplexer session management."""
 
-import os
 import platform
 import re
 import shlex
 import time
 from datetime import datetime
+from pathlib import Path
 from typing import Any, List, Optional
 
 from .lib.logger import get_logger
@@ -61,6 +61,28 @@ class SSHplexConnector:
         redacted = re.sub(r"(\s-i\s+)\S+", r"\1<redacted-key>", command)
         redacted = re.sub(r"(IdentityFile=)\S+", r"\1<redacted-key>", redacted)
         return redacted
+
+    @staticmethod
+    def _first_identity_file(identity_value: str) -> str:
+        """Extract first identity file path from ssh -G identityfile output."""
+        text = str(identity_value or "").strip()
+        if not text:
+            return ""
+        try:
+            parts = shlex.split(text)
+            if parts:
+                return parts[0]
+        except ValueError:
+            pass
+        return text.split()[0]
+
+    @staticmethod
+    def _expand_path(path_value: str) -> str:
+        """Normalize path by expanding user home and trimming whitespace."""
+        text = str(path_value or "").strip()
+        if not text:
+            return ""
+        return str(Path(text).expanduser())
 
     def connect_to_hosts(self, hosts: List[Host], username: str, key_path: Optional[str] = None, port: int = 22, use_panes: bool = True, use_broadcast: bool = False) -> bool:
         """Establish SSH connections to the specified hosts using shell SSH with retry support.
@@ -253,7 +275,8 @@ class SSHplexConnector:
         if not hostname:
             raise ValueError(f"Host missing both ip and name: {host}")
 
-        cmd_parts = ["TERM=xterm-256color", "/usr/bin/ssh"]
+        env_prefix = "TERM=xterm-256color"
+        ssh_args = ["/usr/bin/ssh"]
 
         host_alias = str(getattr(host, "ssh_alias", "") or host.metadata.get("ssh_alias", "")).strip()
         target_override = str(getattr(host, "ssh_hostname", "") or host.metadata.get("ssh_hostname", "")).strip()
@@ -273,7 +296,7 @@ class SSHplexConnector:
             if not port_override and resolved.get("port"):
                 port_override = resolved["port"]
             if not key_override and resolved.get("identityfile"):
-                key_override = resolved["identityfile"].split()[0]
+                key_override = self._first_identity_file(resolved["identityfile"])
 
         # Try to configure proxy if available
         try:
@@ -288,16 +311,18 @@ class SSHplexConnector:
                         # Sanitize proxy credentials to prevent injection
                         proxy_host = proxy.host or ''
                         proxy_user = proxy.username or ''
-                        proxy_key = proxy.key_path or ''
+                        proxy_key = self._expand_path(proxy.key_path or '')
                         
                         # Validate proxy values format
                         if (re.match(r'^[a-zA-Z0-9.-]+$', proxy_host) and
                             re.match(r'^[a-zA-Z0-9._-]+$', proxy_user) and
-                            os.path.isabs(proxy_key) and '..' not in proxy_key):
-                            # Use shlex.quote for safe shell escaping
-                            cmd_parts.extend([
-                                "-o", f"ProxyCommand=/usr/bin/ssh -i {shlex.quote(proxy_key)} -W %h:%p {shlex.quote(proxy_user)}@{shlex.quote(proxy_host)}"
-                            ])
+                            proxy_key):
+                            proxy_command = (
+                                "/usr/bin/ssh "
+                                f"-i {shlex.quote(proxy_key)} "
+                                f"-W %h:%p {shlex.quote(proxy_user)}@{shlex.quote(proxy_host)}"
+                            )
+                            ssh_args.extend(["-o", f"ProxyCommand={proxy_command}"])
                         else:
                             self.logger.warning("Proxy configuration contains invalid values, skipping proxy")
         except Exception:
@@ -308,26 +333,26 @@ class SSHplexConnector:
         if self.config is not None:
             strict_mode = self.config.ssh.strict_host_key_checking
             if strict_mode:
-                cmd_parts.extend(["-o", "StrictHostKeyChecking=yes"])
+                ssh_args.extend(["-o", "StrictHostKeyChecking=yes"])
             else:
                 # Less strict but still reasonable
-                cmd_parts.extend(["-o", "StrictHostKeyChecking=accept-new"])
+                ssh_args.extend(["-o", "StrictHostKeyChecking=accept-new"])
 
             # Configure known_hosts file
-            known_hosts = self.config.ssh.user_known_hosts_file
+            known_hosts = self._expand_path(self.config.ssh.user_known_hosts_file)
             if known_hosts:
-                cmd_parts.extend(["-o", f"UserKnownHostsFile={known_hosts}"])
+                ssh_args.extend(["-o", f"UserKnownHostsFile={known_hosts}"])
             # If empty, SSH uses default ~/.ssh/known_hosts
         else:
             # Use reasonable defaults when config is None
-            cmd_parts.extend(["-o", "StrictHostKeyChecking=accept-new"])
+            ssh_args.extend(["-o", "StrictHostKeyChecking=accept-new"])
 
-        cmd_parts.extend(["-o", "LogLevel=ERROR"])
+        ssh_args.extend(["-o", "LogLevel=ERROR"])
 
         # Add key file if provided
-        effective_key = key_override or (key_path or "")
+        effective_key = self._expand_path(key_override or (key_path or ""))
         if effective_key:
-            cmd_parts.extend(["-i", effective_key])
+            ssh_args.extend(["-i", effective_key])
 
         # Add port if not default
         effective_port = port
@@ -337,17 +362,17 @@ class SSHplexConnector:
             except ValueError:
                 effective_port = port
         if effective_port != 22:
-            cmd_parts.extend(["-p", str(effective_port)])
+            ssh_args.extend(["-p", str(effective_port)])
 
         # Add connection timeout
         timeout = getattr(self.config.ssh, 'timeout', 10) if self.config else 10
-        cmd_parts.extend(["-o", f"ConnectTimeout={timeout}"])
+        ssh_args.extend(["-o", f"ConnectTimeout={timeout}"])
 
         # Add user@hostname with proper escaping
         effective_user = user_override or username
-        cmd_parts.append(f"{shlex.quote(effective_user)}@{shlex.quote(ssh_target)}")
+        ssh_args.append(f"{effective_user}@{ssh_target}")
 
-        return " ".join(cmd_parts)
+        return f"{env_prefix} " + " ".join(shlex.quote(part) for part in ssh_args)
 
     def get_session_name(self) -> str:
         """Get the tmux session name."""

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -53,6 +53,12 @@ class TestHostCache:
         cache = HostCache(cache_dir=str(cache_dir), cache_ttl_hours=48)
         assert cache.cache_ttl == timedelta(hours=48)
 
+    def test_cache_dir_expands_user_home(self, cache_dir, monkeypatch):
+        """HostCache should expand user-home cache directory values."""
+        monkeypatch.setenv("HOME", str(cache_dir))
+        cache = HostCache(cache_dir="~/.cache/sshplex-test")
+        assert str(cache.cache_dir).startswith(str(cache_dir))
+
     def test_save_hosts(self, cache, sample_hosts):
         """Test saving hosts to cache."""
         provider_info = {
@@ -65,6 +71,7 @@ class TestHostCache:
         assert result is True
         assert cache.cache_file.exists()
         assert cache.metadata_file.exists()
+        assert not list(cache.cache_dir.glob("*.tmp"))
 
     def test_load_hosts(self, cache, sample_hosts):
         """Test loading hosts from cache."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -251,8 +251,6 @@ class TestSoTImportConfig:
             repo_url="git@github.com:acme/hosts.git",
             branch="main",
             source_pattern="hosts/**/*.y*ml",
-            path="hosts",
-            file_glob="**/*.y*ml",
             auto_pull=True,
             pull_interval_seconds=120,
             priority=100,

--- a/tests/test_sot/test_factory.py
+++ b/tests/test_sot/test_factory.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-from sshplex.lib.sot.base import Host
+from sshplex.lib.sot.base import Host, SoTProvider
 from sshplex.lib.sot.factory import SoTFactory
 from sshplex.lib.sot.git import GitProvider
 
@@ -32,7 +32,7 @@ class InMemoryCache:
         return True
 
 
-class DummyProvider:
+class DummyProvider(SoTProvider):
     """Minimal provider stub for deterministic host-return tests."""
 
     def __init__(self, provider_name: str, hosts: list[Host]) -> None:
@@ -53,12 +53,9 @@ class DummyProvider:
 def _make_config(
     imports: list[SimpleNamespace],
     providers: list[str],
-    providers_field_set: bool | None = None,
 ) -> SimpleNamespace:
     """Build a minimal config object for SoTFactory tests."""
     sot_config = SimpleNamespace(import_=imports, providers=providers)
-    if providers_field_set is not None:
-        sot_config.model_fields_set = {"providers"} if providers_field_set else set()
 
     return SimpleNamespace(
         sot=sot_config,
@@ -112,15 +109,13 @@ def test_initialize_providers_includes_git_when_enabled() -> None:
             type="git",
             repo_url="git@github.com:acme/hosts.git",
             branch="main",
-            path="hosts",
-            file_glob="**/*.y*ml",
             auto_pull=True,
             pull_interval_seconds=300,
             priority=100,
             pull_strategy="ff-only",
         )
     ]
-    config = _make_config(imports=imports, providers=["git"], providers_field_set=True)
+    config = _make_config(imports=imports, providers=["git"])
 
     git_provider = MagicMock()
     git_provider.connect.return_value = True
@@ -149,8 +144,8 @@ def test_initialize_providers_infers_enabled_types_when_providers_not_set() -> N
             default_filters={},
         ),
     ]
-    # Emulate pydantic model where providers is defaulted but not present in input.
-    config = _make_config(imports=imports, providers=["static"], providers_field_set=False)
+    # Empty providers means infer enabled types from configured imports.
+    config = _make_config(imports=imports, providers=[])
 
     static_provider = MagicMock()
     static_provider.connect.return_value = True
@@ -218,6 +213,45 @@ def test_get_all_hosts_merge_is_consistent_between_modes() -> None:
     assert factory.cache.saved_info["fetch_mode"] == "parallel"
 
 
+def test_get_all_hosts_uses_filter_aware_memory_cache() -> None:
+    """Different filters should not reuse each other's in-memory cache entries."""
+    config = _make_config(imports=[], providers=[])
+
+    with patch("sshplex.lib.sot.factory.HostCache", InMemoryCache):
+        factory = SoTFactory(config)
+
+    class FilterAwareProvider(DummyProvider):
+        def __init__(self) -> None:
+            super().__init__("dynamic", [])
+            self.calls: list[dict[str, str]] = []
+
+        def get_hosts(self, filters=None):  # noqa: ANN001
+            active_filters = dict(filters or {})
+            self.calls.append({str(k): str(v) for k, v in active_filters.items()})
+            role = str(active_filters.get("role", "unknown"))
+            return [
+                Host(
+                    name=f"node-{role}",
+                    ip="10.0.0.10" if role == "web" else "10.0.0.20",
+                    provider="dynamic",
+                    role=role,
+                    sources=["dynamic"],
+                )
+            ]
+
+    provider = FilterAwareProvider()
+    factory.providers = [provider]
+
+    web_hosts = factory.get_all_hosts(additional_filters={"role": "web"}, force_refresh=False)
+    db_hosts = factory.get_all_hosts(additional_filters={"role": "db"}, force_refresh=False)
+    cached_web_hosts = factory.get_all_hosts(additional_filters={"role": "web"}, force_refresh=False)
+
+    assert web_hosts[0].metadata["role"] == "web"
+    assert db_hosts[0].metadata["role"] == "db"
+    assert cached_web_hosts[0].metadata["role"] == "web"
+    assert len(provider.calls) == 2
+
+
 def test_sync_git_sources_initializes_git_providers_without_full_init(tmp_path) -> None:
     """sync_git_sources should work even when non-git providers are not initialized."""
     imports = [
@@ -226,15 +260,13 @@ def test_sync_git_sources_initializes_git_providers_without_full_init(tmp_path) 
             type="git",
             repo_url="git@github.com:acme/hosts.git",
             branch="main",
-            path="hosts",
-            file_glob="**/*.y*ml",
             auto_pull=True,
             pull_interval_seconds=300,
             priority=100,
             pull_strategy="ff-only",
         )
     ]
-    config = _make_config(imports=imports, providers=["git"], providers_field_set=True)
+    config = _make_config(imports=imports, providers=["git"])
 
     with patch("sshplex.lib.sot.factory.HostCache", InMemoryCache):
         factory = SoTFactory(config)

--- a/tests/test_sot/test_git.py
+++ b/tests/test_sot/test_git.py
@@ -16,8 +16,6 @@ def _git_import(**overrides):
         "repo_url": "git@github.com:acme/hosts.git",
         "branch": "main",
         "source_pattern": "hosts/**/*.y*ml",
-        "path": "hosts",
-        "file_glob": "**/*.y*ml",
         "auto_pull": True,
         "pull_interval_seconds": 300,
         "priority": 100,
@@ -168,7 +166,6 @@ all:
 
     provider = GitProvider(
         _git_import(
-            path="inventory",
             source_pattern="inventory/**/*.y*ml",
             inventory_format="ansible",
             default_filters={"groups": ["webservers"]},
@@ -213,7 +210,6 @@ all:
 
     provider = GitProvider(
         _git_import(
-            path="inventory",
             source_pattern="inventory/**/*.y*ml",
             inventory_format="ansible",
             default_filters={"groups": ["webservers"]},
@@ -253,7 +249,6 @@ all:
 
     provider = GitProvider(
         _git_import(
-            path="inventory",
             source_pattern="inventory/**/*.y*ml",
             inventory_format="ansible",
         ),
@@ -290,7 +285,6 @@ all:
 
     provider = GitProvider(
         _git_import(
-            path="inventory",
             source_pattern="inventory/**/*.y*ml",
             inventory_format="ansible",
         ),

--- a/tests/test_sot/test_netbox.py
+++ b/tests/test_sot/test_netbox.py
@@ -13,8 +13,9 @@ class TestNetBoxProvider:
     @pytest.fixture
     def mock_pynetbox(self):
         """Mock pynetbox module."""
-        with patch('sshplex.lib.sot.netbox.pynetbox') as mock:
-            yield mock
+        mock_module = MagicMock()
+        with patch('sshplex.lib.sot.netbox._import_pynetbox', return_value=mock_module):
+            yield mock_module
 
     @pytest.fixture
     def mock_vm(self):
@@ -82,8 +83,13 @@ class TestNetBoxProvider:
         mock_pynetbox.api.side_effect = Exception('Connection failed')
         
         result = provider.connect()
-        
+
         assert result is False
+
+    def test_connect_fails_when_pynetbox_missing(self, provider):
+        """Provider should fail gracefully when pynetbox is unavailable."""
+        with patch('sshplex.lib.sot.netbox._import_pynetbox', return_value=None):
+            assert provider.connect() is False
 
     def test_test_connection_success(self, provider, mock_pynetbox):
         """Test connection test when connected."""

--- a/tests/test_sshplex_connector.py
+++ b/tests/test_sshplex_connector.py
@@ -1,0 +1,84 @@
+"""Tests for SSH command construction hardening."""
+
+from __future__ import annotations
+
+import shlex
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from sshplex.lib.sot.base import Host
+from sshplex.sshplex_connector import SSHplexConnector
+
+
+def _build_connector(config: SimpleNamespace) -> SSHplexConnector:
+    connector = SSHplexConnector.__new__(SSHplexConnector)
+    connector.config = config
+    connector.logger = MagicMock()
+    return connector
+
+
+def _base_config() -> SimpleNamespace:
+    return SimpleNamespace(
+        ssh=SimpleNamespace(
+            strict_host_key_checking=False,
+            user_known_hosts_file="",
+            timeout=10,
+            proxy=[],
+            retry=SimpleNamespace(enabled=False, max_attempts=1, delay_seconds=1, exponential_backoff=False),
+            username="admin",
+            key_path="~/.ssh/id_ed25519",
+            port=22,
+        ),
+    )
+
+
+def test_build_ssh_command_quotes_key_and_known_hosts_paths() -> None:
+    """SSH command should preserve paths containing spaces."""
+    config = _base_config()
+    config.ssh.user_known_hosts_file = "~/.ssh/known hosts"
+    connector = _build_connector(config)
+    host = Host(name="web-01", ip="10.0.0.10", provider="static")
+
+    command = connector._build_ssh_command(
+        host=host,
+        username="admin",
+        key_path="~/.ssh/private keys/id test",
+        port=22,
+    )
+    parts = shlex.split(command)
+
+    expanded_key = str(Path("~/.ssh/private keys/id test").expanduser())
+    expanded_known_hosts = str(Path("~/.ssh/known hosts").expanduser())
+
+    assert parts[0] == "TERM=xterm-256color"
+    assert parts[1] == "/usr/bin/ssh"
+    assert parts[parts.index("-i") + 1] == expanded_key
+    assert f"UserKnownHostsFile={expanded_known_hosts}" in parts
+
+
+def test_build_ssh_command_accepts_proxy_key_with_tilde_path() -> None:
+    """Proxy command should include expanded proxy key path."""
+    config = _base_config()
+    config.ssh.proxy = [
+        SimpleNamespace(
+            name="proxy-a",
+            imports=["static-a"],
+            host="proxy.example.com",
+            username="jumper",
+            key_path="~/.ssh/proxy key",
+        )
+    ]
+    connector = _build_connector(config)
+    host = Host(name="db-01", ip="10.0.0.20", provider="static-a")
+
+    command = connector._build_ssh_command(host=host, username="admin", key_path=None, port=22)
+    parts = shlex.split(command)
+
+    proxy_option = next(
+        (parts[idx + 1] for idx, value in enumerate(parts) if value == "-o" and idx + 1 < len(parts) and parts[idx + 1].startswith("ProxyCommand=")),
+        "",
+    )
+
+    assert proxy_option.startswith("ProxyCommand=/usr/bin/ssh ")
+    assert str(Path("~/.ssh/proxy key").expanduser()) in proxy_option


### PR DESCRIPTION
## Summary
- Refactor core host/model/cache paths for correctness and future extension: host metadata handling is explicit, cache writes are atomic, cache keys are filter-aware, and provider/back-end catalogs are centralized in shared config constants.
- Simplify SoT and config surfaces by removing legacy git `path`/`file_glob` compatibility plumbing in runtime/onboarding/settings, making `source_pattern` the canonical source selector.
- Improve runtime robustness by lazy-loading NetBox dependency, hardening SSH command path quoting/expansion (key + known_hosts + proxy key), and moving tmux session list refreshes off the UI thread.

## Validation
- `./.venv/bin/ruff check sshplex tests`
- `./.venv/bin/mypy sshplex --ignore-missing-imports`
- `./.venv/bin/python -m pytest tests -q`